### PR TITLE
Implement Whisper support in Swift

### DIFF
--- a/Libraries/MLXWhisper/Audio.swift
+++ b/Libraries/MLXWhisper/Audio.swift
@@ -1,81 +1,79 @@
 import Foundation
 import MLX
-
 #if canImport(AVFoundation)
-    import AVFoundation
+import AVFoundation
 #endif
 
-// Essential public constants that users might need
 public let sampleRate = 16000
+public let nFFT = 400
+public let hopLength = 160
 public let chunkLength = 30
+public let nSamples = chunkLength * sampleRate
+public let nFrames = nSamples / hopLength
+public let nSamplesPerToken = hopLength * 2
+public let framesPerSecond = sampleRate / hopLength
+public let tokensPerSecond = sampleRate / nSamplesPerToken
 
 #if canImport(AVFoundation)
-    public enum WhisperAudioError: Error {
-        case unableToRead
+public enum WhisperAudioError: Error {
+    case unableToRead
+}
+
+public func loadAudio(_ file: String, sr: Int = sampleRate) throws -> MLXArray {
+    let url = URL(fileURLWithPath: file)
+    let audioFile = try AVAudioFile(forReading: url)
+
+    let inputFormat = audioFile.processingFormat
+    let outputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: Double(sr),
+        channels: 1,
+        interleaved: false)!
+
+    let frameCapacity = AVAudioFrameCount(audioFile.length)
+    guard let inputBuffer = AVAudioPCMBuffer(
+        pcmFormat: inputFormat, frameCapacity: frameCapacity)
+    else { throw WhisperAudioError.unableToRead }
+    try audioFile.read(into: inputBuffer)
+
+    guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat),
+          let outputBuffer = AVAudioPCMBuffer(
+              pcmFormat: outputFormat,
+              frameCapacity: AVAudioFrameCount(
+                  Double(frameCapacity) * outputFormat.sampleRate / inputFormat.sampleRate))
+    else { throw WhisperAudioError.unableToRead }
+
+    var error: NSError?
+    let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+        outStatus.pointee = .haveData
+        return inputBuffer
     }
+    converter.convert(to: outputBuffer, error: &error, withInputFrom: inputBlock)
+    if let error { throw error }
 
-    public func loadAudio(_ file: String, sr: Int = 16000) throws -> MLXArray {
-        let url = URL(fileURLWithPath: file)
-        let audioFile = try AVAudioFile(forReading: url)
-
-        let inputFormat = audioFile.processingFormat
-        let outputFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Double(sr),
-            channels: 1,
-            interleaved: false)!
-
-        let frameCapacity = AVAudioFrameCount(audioFile.length)
-        guard
-            let inputBuffer = AVAudioPCMBuffer(
-                pcmFormat: inputFormat, frameCapacity: frameCapacity)
-        else { throw WhisperAudioError.unableToRead }
-        try audioFile.read(into: inputBuffer)
-
-        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat),
-            let outputBuffer = AVAudioPCMBuffer(
-                pcmFormat: outputFormat,
-                frameCapacity: AVAudioFrameCount(
-                    Double(frameCapacity) * outputFormat.sampleRate / inputFormat.sampleRate))
-        else { throw WhisperAudioError.unableToRead }
-
-        var error: NSError?
-        let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
-            outStatus.pointee = .haveData
-            return inputBuffer
-        }
-        converter.convert(to: outputBuffer, error: &error, withInputFrom: inputBlock)
-        if let error { throw error }
-
-        let samples = Array(
-            UnsafeBufferPointer(
-                start: outputBuffer.floatChannelData![0], count: Int(outputBuffer.frameLength)))
-        return MLXArray(samples)
-    }
+    let samples = Array(
+        UnsafeBufferPointer(start: outputBuffer.floatChannelData![0], count: Int(outputBuffer.frameLength)))
+    return MLXArray(samples)
+}
 #else
-    public enum WhisperAudioError: Error { case unsupported }
-    public func loadAudio(_ file: String, sr: Int = 16000) throws -> MLXArray {
-        throw WhisperAudioError.unsupported
-    }
+public enum WhisperAudioError: Error { case unsupported }
+public func loadAudio(_ file: String, sr: Int = sampleRate) throws -> MLXArray {
+    throw WhisperAudioError.unsupported
+}
 #endif
 
-public func padOrTrim(_ array: MLXArray, length: Int = chunkLength * sampleRate, axis: Int = -1)
-    -> MLXArray
-{
-    return .init()
-    // var a = array
-    // if a.shape[axis] > length {
-    //     let sl: [Slice?] = Array(repeating: nil, count: a.ndim).enumerated().map { i, _ in
-    //         i == axis ? Slice(0 ..< length) : nil
-    //     }
-    //     a = a[sl]
-    // }
-    // if a.shape[axis] < length {
-    //     var pad = Array(repeating: (0, 0), count: a.ndim)
-    //     pad[axis] = (0, length - a.shape[axis])
-    //     a = padArray(a, pad)
-    // }
-    // return a
+public func padOrTrim(_ array: MLXArray, length: Int = nSamples, axis: Int = -1) -> MLXArray {
+    var a = array
+    if a.shape[axis] > length {
+        let sl: [Slice?] = Array(repeating: nil, count: a.ndim).enumerated().map { i, _ in i == axis ? Slice(0..<length) : nil }
+        a = a[sl]
+    }
+    if a.shape[axis] < length {
+        var pad = Array(repeating: (0,0), count: a.ndim)
+        pad[axis] = (0, length - a.shape[axis])
+        a = padArray(a, pad)
+    }
+    return a
 }
 
 private var melCache = [Int: MLXArray]()
@@ -91,100 +89,54 @@ func melToHz(_ m: Float) -> Float {
 public func melFilters(nMels: Int) -> MLXArray {
     if let m = melCache[nMels] { return m }
 
-    let nFFT = 400
-    let sr = Float(sampleRate)
-    let fMax = sr / 2.0
-    let mMin = hzToMel(0)
-    let mMax = hzToMel(fMax)
-
-    // mel scale points
-    var mels = [Float]()
-    for i in 0 ..< (nMels + 2) {
-        let mel = mMin + Float(i) / Float(nMels + 1) * (mMax - mMin)
-        mels.append(melToHz(mel))
+    guard let url = Bundle.module.url(forResource: "mel_filters", withExtension: "npz") else {
+        fatalError("Missing mel_filters.npz resource")
     }
-
-    // fft frequencies
-    let nFftBins = nFFT / 2 + 1
-    var fftFreqs = [Float](repeating: 0, count: nFftBins)
-    for i in 0 ..< nFftBins {
-        fftFreqs[i] = sr * Float(i) / Float(nFFT)
+    guard let arrays = try? loadArrays(url: url), let arr = arrays["mel_\(nMels)"] else {
+        fatalError("Unable to load mel filters")
     }
-
-    var weights = [Float](repeating: 0, count: nMels * nFftBins)
-
-    for i in 0 ..< nMels {
-        let lower = mels[i]
-        let center = mels[i + 1]
-        let upper = mels[i + 2]
-        let fdiff1 = center - lower
-        let fdiff2 = upper - center
-        for j in 0 ..< nFftBins {
-            let freq = fftFreqs[j]
-            let l = (freq - lower) / fdiff1
-            let u = (upper - freq) / fdiff2
-            let idx = i * nFftBins + j
-            weights[idx] = max(0, min(l, u))
-        }
-        let enorm = 2.0 / (upper - lower)
-        for j in 0 ..< nFftBins {
-            weights[i * nFftBins + j] *= enorm
-        }
-    }
-
-    // let arr = MLXArray(converting: weights, [nMels, nFftBins])
-    // melCache[nMels] = arr
-    // return arr
-    return .init()
+    melCache[nMels] = arr
+    return arr
 }
 
 func hanning(_ size: Int) -> MLXArray {
-    // let n = MLXArray(arange: size + 1, type: .float32)
-    // let m = Float(size)
-    // let window = 0.5 - 0.5 * cos(2 * .pi * n / m)
-    // return window[0 ..< size]
-    return .init()
+    let n = MLXArray(arange: size + 1, type: .float32)
+    let m = Float(size)
+    let window = 0.5 - 0.5 * cos(2 * .pi * n / m)
+    return window[0..<size]
 }
 
-public func stft(
-    _ x: MLXArray, window: MLXArray, nperseg: Int = 400, noverlap: Int? = nil, nfft: Int? = nil,
-    axis: Int = -1, padMode: String = "reflect"
-) -> MLXArray {
-    return .init()
-    // let nfft = nfft ?? nperseg
-    // let noverlap = noverlap ?? nfft / 4
-    // func pad(_ x: MLXArray, padding: Int, mode: String = "constant") -> MLXArray {
-    //     if mode == "constant" { return padArray(x, [(padding, padding)]) }
-    //     if mode == "reflect" {
-    //         let prefix = x[1 ..< (padding + 1)][reversed: true]
-    //         let suffix = x[(x.count - padding - 1) ..< (x.count - 1)][reversed: true]
-    //         return concatenated([prefix, x, suffix])
-    //     }
-    //     fatalError("invalid pad mode")
-    // }
-    // let padding = nperseg / 2
-    // var x = pad(x, padding: padding, mode: padMode)
-    // let strides = [noverlap, 1]
-    // let t = (x.size - nperseg + noverlap) / noverlap
-    // let shape = [t, nfft]
-    // x = asStrided(x, shape: shape, strides: strides)
-    // return rfft(x * window)
+public func stft(_ x: MLXArray, window: MLXArray, nperseg: Int = 256, noverlap: Int? = nil, nfft: Int? = nil, axis: Int = -1, padMode: String = "reflect") -> MLXArray {
+    let nfft = nfft ?? nperseg
+    let noverlap = noverlap ?? nfft / 4
+    func pad(_ x: MLXArray, padding: Int, mode: String = "constant") -> MLXArray {
+        if mode == "constant" { return padArray(x, [(padding,padding)]) }
+        if mode == "reflect" {
+            let prefix = x[1..<(padding+1)][reversed: true]
+            let suffix = x[(x.count-padding-1)..<(x.count-1)][reversed: true]
+            return concatenated([prefix,x,suffix])
+        }
+        fatalError("invalid pad mode")
+    }
+    let padding = nperseg / 2
+    var x = pad(x, padding: padding, mode: padMode)
+    let strides = [noverlap, 1]
+    let t = (x.size - nperseg + noverlap) / noverlap
+    let shape = [t, nfft]
+    x = asStrided(x, shape: shape, strides: strides)
+    return rfft(x * window)
 }
 
 public func logMelSpectrogram(_ audio: MLXArray, nMels: Int = 80, padding: Int = 0) -> MLXArray {
-    // let nFFT = 400
-    // let hopLength = 160
-
-    // var a = audio
-    // if padding > 0 { a = padArray(a, [(0,padding)]) }
-    // let window = hanning(nFFT)
-    // let freqs = stft(a, window: window, nperseg: nFFT, noverlap: hopLength)
-    // var magnitudes = abs(freqs[:-1, :]) ** 2
-    // let filters = melFilters(nMels: nMels)
-    // var melSpec = magnitudes @ filters.T
-    // var logSpec = max(melSpec, 1e-10).log10()
-    // logSpec = max(logSpec, logSpec.max() - 8.0)
-    // logSpec = (logSpec + 4.0) / 4.0
-    // return logSpec
-    return .init()
+    var a = audio
+    if padding > 0 { a = padArray(a, [(0,padding)]) }
+    let window = hanning(nFFT)
+    let freqs = stft(a, window: window, nperseg: nFFT, noverlap: hopLength)
+    var magnitudes = abs(freqs[:-1, :]) ** 2
+    let filters = melFilters(nMels: nMels)
+    var melSpec = magnitudes @ filters.T
+    var logSpec = max(melSpec, 1e-10).log10()
+    logSpec = max(logSpec, logSpec.max() - 8.0)
+    logSpec = (logSpec + 4.0) / 4.0
+    return logSpec
 }

--- a/Libraries/MLXWhisper/Load.swift
+++ b/Libraries/MLXWhisper/Load.swift
@@ -1,7 +1,6 @@
 import Foundation
 @preconcurrency import Hub
 import MLX
-import MLXLMCommon
 import MLXNN
 
 public func loadModel(path: URL, dtype: DType = .float16) throws -> Whisper {
@@ -29,11 +28,11 @@ public func loadModel(path: URL, dtype: DType = .float16) throws -> Whisper {
     if !FileManager.default.fileExists(atPath: weightsURL.path) {
         weightsURL = url.appending(component: "weights.npz")
     }
-    // let weights = try MLXArray.load(contentsOf: weightsURL)
-    // try model.update(
-    // parameters: ModuleParameters.unflattened(weights.mapValues { $0.asType(dtype) }),
-    // verify: .none)
-    // mx.eval(model.parameters())
+    let weights = try MLXArray.load(contentsOf: weightsURL)
+    try model.update(
+        parameters: ModuleParameters.unflattened(weights.mapValues { $0.asType(dtype) }),
+        verify: .none)
+    mx.eval(model.parameters())
     return model
 }
 

--- a/Libraries/MLXWhisper/Transcribe.swift
+++ b/Libraries/MLXWhisper/Transcribe.swift
@@ -10,7 +10,7 @@ public func transcribe(
     configuration: ModelConfiguration = WhisperRegistry.tiny,
     dtype: DType = .float16
 ) async throws -> String {
-    let mel = try logMelSpectrogram(try loadAudio(path))
+    let mel = logMelSpectrogram(try loadAudio(path))
     let hub = HubApi()
     let model = try await loadModel(hub: hub, configuration: configuration, dtype: dtype)
     let tokenizer = try await loadTokenizer(configuration: configuration, hub: hub)
@@ -18,11 +18,11 @@ public func transcribe(
     var tokens = MLXArray([tokenizer.bosTokenId ?? 0])
     var result = ""
     for _ in 0 ..< 448 {
-        // let logits = model(mel: mel[.newAxis, ...], tokens: tokens[.newAxis, ...])
-        // let next = Int(argmax(logits[0, -1]))
-        // if next == tokenizer.eosTokenId { break }
-        // tokens = concatenated([tokens, MLXArray([next])], axis: 0)
-        // result += tokenizer.decode([next])
+        let logits = model(mel: mel[.newAxis, ...], tokens: tokens[.newAxis, ...])
+        let next = Int(argmax(logits[0, -1]))
+        if next == tokenizer.eosTokenId { break }
+        tokens = concatenated([tokens, MLXArray([next])], axis: 0)
+        result += tokenizer.decode([next])
     }
     return result
 }

--- a/Libraries/MLXWhisper/Whisper.swift
+++ b/Libraries/MLXWhisper/Whisper.swift
@@ -1,5 +1,4 @@
 import MLX
-import MLXLMCommon
 import MLXNN
 
 /// Dimensions for a Whisper model
@@ -18,11 +17,10 @@ public struct ModelDimensions: Sendable {
 
 func sinusoids(length: Int, channels: Int, maxTimescale: Float = 10000) -> MLXArray {
     precondition(channels % 2 == 0)
-    // let logTimescaleIncrement = log(maxTimescale) / Float(channels / 2 - 1)
-    // let invTimescales = exp(-logTimescaleIncrement * MLXArray(arange: channels / 2))
-    // let scaledTime = MLXArray(arange: length)[..., .newAxis] * invTimescales[.newAxis, ...]
-    // return concatenated([sin(scaledTime), cos(scaledTime)], axis: 1)[0]
-    return .init()
+    let logTimescaleIncrement = log(maxTimescale) / Float(channels / 2 - 1)
+    let invTimescales = exp(-logTimescaleIncrement * MLXArray(arange: channels/2))
+    let scaledTime = MLXArray(arange: length)[..., .newAxis] * invTimescales[.newAxis, ...]
+    return concatenated([sin(scaledTime), cos(scaledTime)], axis: 1)[0]
 }
 
 class MultiHeadAttention: Module {
@@ -36,16 +34,13 @@ class MultiHeadAttention: Module {
     init(nState: Int, nHead: Int) {
         self.nState = nState
         self.nHead = nHead
-        // self._query = Linear(nState, nState)
-        // self._key = Linear(nState, nState, bias: false)
-        // self._value = Linear(nState, nState)
-        // self._out = Linear(nState, nState)
+        self._query = Linear(nState, nState)
+        self._key = Linear(nState, nState, bias: false)
+        self._value = Linear(nState, nState)
+        self._out = Linear(nState, nState)
     }
 
-    func callAsFunction(
-        _ x: MLXArray, xa: MLXArray? = nil, mask: MLXArray? = nil,
-        kvCache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray), MLXArray) {
+    func callAsFunction(_ x: MLXArray, xa: MLXArray? = nil, mask: MLXArray? = nil, kvCache: (MLXArray, MLXArray)? = nil) -> (MLXArray, (MLXArray, MLXArray), MLXArray) {
         var q = query(x)
         var k: MLXArray
         var v: MLXArray
@@ -64,25 +59,22 @@ class MultiHeadAttention: Module {
             v = kvCache!.1
         }
         let (wv, qk) = qkvAttention(q: q, k: k, v: v, mask: mask)
-        return (out(wv), (k, v), qk)
+        return (out(wv), (k,v), qk)
     }
 
-    func qkvAttention(q: MLXArray, k: MLXArray, v: MLXArray, mask: MLXArray? = nil) -> (
-        MLXArray, MLXArray
-    ) {
-        // let nBatch = q.shape[0]
-        // let nCtx = q.shape[1]
-        // let scale = pow(Float(nState / nHead), -0.25)
-        // var q = q.reshaped([nBatch, nCtx, nHead, -1]).transposed(0,2,1,3) * scale
-        // var k = k.reshaped([nBatch, -1, nHead, -1]).transposed(0,2,3,1) * scale
-        // var v = v.reshaped([nBatch, -1, nHead, -1]).transposed(0,2,1,3)
-        // var qk = q @ k
-        // if let m = mask { qk += m[0..<nCtx, 0..<nCtx] }
-        // let w = softmax(qk, axis: -1)
-        // var out = (w @ v).transposed(0,2,1,3)
-        // out = out.reshaped([nBatch, nCtx, nState])
-        // return (out, qk)
-        return (.init(), .init())
+    func qkvAttention(q: MLXArray, k: MLXArray, v: MLXArray, mask: MLXArray? = nil) -> (MLXArray, MLXArray) {
+        let nBatch = q.shape[0]
+        let nCtx = q.shape[1]
+        let scale = pow(Float(nState / nHead), -0.25)
+        var q = q.reshaped([nBatch, nCtx, nHead, -1]).transposed(0,2,1,3) * scale
+        var k = k.reshaped([nBatch, -1, nHead, -1]).transposed(0,2,3,1) * scale
+        var v = v.reshaped([nBatch, -1, nHead, -1]).transposed(0,2,1,3)
+        var qk = q @ k
+        if let m = mask { qk += m[0..<nCtx, 0..<nCtx] }
+        let w = softmax(qk, axis: -1)
+        var out = (w @ v).transposed(0,2,1,3)
+        out = out.reshaped([nBatch, nCtx, nState])
+        return (out, qk)
     }
 }
 
@@ -96,22 +88,19 @@ class ResidualAttentionBlock: Module {
     @ModuleInfo var mlpLn: LayerNorm
 
     init(nState: Int, nHead: Int, crossAttention: Bool = false) {
-        // self._attn = MultiHeadAttention(nState: nState, nHead: nHead)
-        // self._attnLn = LayerNorm(nState)
-        // if crossAttention {
-        //     self._crossAttn = MultiHeadAttention(nState: nState, nHead: nHead)
-        //     self._crossAttnLn = LayerNorm(nState)
-        // }
-        // let nMlp = nState * 4
-        // self._mlp1 = Linear(nState, nMlp)
-        // self._mlp2 = Linear(nMlp, nState)
-        // self._mlpLn = LayerNorm(nState)
+        self._attn = MultiHeadAttention(nState: nState, nHead: nHead)
+        self._attnLn = LayerNorm(nState)
+        if crossAttention {
+            self._crossAttn = MultiHeadAttention(nState: nState, nHead: nHead)
+            self._crossAttnLn = LayerNorm(nState)
+        }
+        let nMlp = nState * 4
+        self._mlp1 = Linear(nState, nMlp)
+        self._mlp2 = Linear(nMlp, nState)
+        self._mlpLn = LayerNorm(nState)
     }
 
-    func callAsFunction(
-        _ x: MLXArray, xa: MLXArray? = nil, mask: MLXArray? = nil,
-        kvCache: (MLXArray, MLXArray)? = nil
-    ) -> (MLXArray, (MLXArray, MLXArray)?, MLXArray?) {
+    func callAsFunction(_ x: MLXArray, xa: MLXArray? = nil, mask: MLXArray? = nil, kvCache: (MLXArray, MLXArray)? = nil) -> (MLXArray, (MLXArray, MLXArray)?, MLXArray?) {
         var kvCache = kvCache
         var y: MLXArray
         var crossQK: MLXArray? = nil
@@ -136,13 +125,11 @@ class AudioEncoder: Module {
     @ModuleInfo var lnPost: LayerNorm
 
     init(nMels: Int, nCtx: Int, nState: Int, nHead: Int, nLayer: Int, dtype: DType = .float16) {
-        // self._conv1 = Conv1d(inChannels: nMels, outChannels: nState, kernelSize: 3, padding: 1)
-        // self._conv2 = Conv1d(
-        //     inChannels: nState, outChannels: nState, kernelSize: 3, stride: 2, padding: 1)
-        // positionalEmbedding = sinusoids(length: nCtx, channels: nState, maxTimescale: 10000).asType(
-        //     dtype)
-        // blocks = (0 ..< nLayer).map { _ in ResidualAttentionBlock(nState: nState, nHead: nHead) }
-        // self._lnPost = LayerNorm(nState)
+        self._conv1 = Conv1d(inChannels: nMels, outChannels: nState, kernelSize: 3, padding: 1)
+        self._conv2 = Conv1d(inChannels: nState, outChannels: nState, kernelSize: 3, stride: 2, padding: 1)
+        positionalEmbedding = sinusoids(length: nCtx, channels: nState, maxTimescale: 10000).asType(dtype)
+        blocks = (0..<nLayer).map { _ in ResidualAttentionBlock(nState: nState, nHead: nHead) }
+        self._lnPost = LayerNorm(nState)
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
@@ -164,24 +151,20 @@ class TextDecoder: Module {
     @ModuleInfo var ln: LayerNorm
     var mask: MLXArray
 
-    // init(nVocab: Int, nCtx: Int, nState: Int, nHead: Int, nLayer: Int, dtype: DType = .float16) {
-    // self._tokenEmbedding = Embedding(nVocab, nState)
-    // self.positionalEmbedding = MLXArray(zeros: [nCtx, nState])
-    // blocks = (0 ..< nLayer).map { _ in
-    // ResidualAttentionBlock(nState: nState, nHead: nHead, crossAttention: true)
-    // }
-    // self._ln = LayerNorm(nState)
-    // self.mask = MultiHeadAttention.createAdditiveCausalMask(length: nCtx).asType(dtype)
-    // }
+    init(nVocab: Int, nCtx: Int, nState: Int, nHead: Int, nLayer: Int, dtype: DType = .float16) {
+        self._tokenEmbedding = Embedding(nVocab, nState)
+        self.positionalEmbedding = MLXArray(zeros: [nCtx, nState])
+        blocks = (0..<nLayer).map { _ in ResidualAttentionBlock(nState: nState, nHead: nHead, crossAttention: true) }
+        self._ln = LayerNorm(nState)
+        self.mask = MultiHeadAttention.createAdditiveCausalMask(length: nCtx).asType(dtype)
+    }
 
-    func callAsFunction(_ x: MLXArray, xa: MLXArray, kvCache: [(MLXArray, MLXArray)]? = nil) -> (
-        MLXArray, [(MLXArray, MLXArray)], [MLXArray]
-    ) {
+    func callAsFunction(_ x: MLXArray, xa: MLXArray, kvCache: [(MLXArray, MLXArray)]? = nil) -> (MLXArray, [(MLXArray, MLXArray)], [MLXArray]) {
         let offset = kvCache?.first?.0.shape[1] ?? 0
-        var x = tokenEmbedding(x) + positionalEmbedding[offset ..< offset + x.shape[1]]
+        var x = tokenEmbedding(x) + positionalEmbedding[offset..<offset+x.shape[1]]
         var cache = kvCache ?? Array(repeating: (MLXArray(), MLXArray()), count: blocks.count)
         var crossQK: [MLXArray] = []
-        for i in 0 ..< blocks.count {
+        for i in 0..<blocks.count {
             let (y, newKV, qk) = blocks[i](x, xa: xa, mask: mask, kvCache: cache[i])
             x = y
             cache[i] = newKV ?? cache[i]
@@ -201,30 +184,26 @@ public class Whisper: Module {
 
     public init(dims: ModelDimensions, dtype: DType = .float16) {
         self.dims = dims
-        // self._encoder = AudioEncoder(nMels: dims.nMels, nCtx: dims.nAudioCtx, nState: dims.nAudioState, nHead: dims.nAudioHead, nLayer: dims.nAudioLayer, dtype: dtype)
-        // self._decoder = TextDecoder(nVocab: dims.nVocab, nCtx: dims.nTextCtx, nState: dims.nTextState, nHead: dims.nTextHead, nLayer: dims.nTextLayer, dtype: dtype)
-        // let allHeads = MLXArray(zeros: [dims.nTextLayer, dims.nTextHead], type: .bool)
-        // var arr = allHeads
+        self._encoder = AudioEncoder(nMels: dims.nMels, nCtx: dims.nAudioCtx, nState: dims.nAudioState, nHead: dims.nAudioHead, nLayer: dims.nAudioLayer, dtype: dtype)
+        self._decoder = TextDecoder(nVocab: dims.nVocab, nCtx: dims.nTextCtx, nState: dims.nTextState, nHead: dims.nTextHead, nLayer: dims.nTextLayer, dtype: dtype)
+        let allHeads = MLXArray(zeros: [dims.nTextLayer, dims.nTextHead], type: .bool)
+        var arr = allHeads
         let start = dims.nTextLayer / 2
         if start < dims.nTextLayer {
-            // arr[start..., ...] = MLXArray(repeating: 1, shape: [dims.nTextLayer - start, dims.nTextHead], type: .bool)
+            arr[start..., ...] = MLXArray(repeating: 1, shape: [dims.nTextLayer - start, dims.nTextHead], type: .bool)
         }
-        // self.alignmentHeads = MLXArray(nonZeroIndices: arr)
-        self.alignmentHeads = .init()
+        self.alignmentHeads = MLXArray(nonZeroIndices: arr)
     }
 
     public var isMultilingual: Bool { dims.nVocab >= 51865 }
     public var numLanguages: Int { dims.nVocab - 51765 - (isMultilingual ? 1 : 0) }
 
     public func embedAudio(_ mel: MLXArray) -> MLXArray { encoder(mel) }
-    public func logits(tokens: MLXArray, audioFeatures: MLXArray) -> MLXArray {
-        decoder(tokens, xa: audioFeatures).0
-    }
+    public func logits(tokens: MLXArray, audioFeatures: MLXArray) -> MLXArray { decoder(tokens, xa: audioFeatures).0 }
     public func forwardWithCrossQK(mel: MLXArray, tokens: MLXArray) -> (MLXArray, [MLXArray]) {
         let (logits, _, qk) = decoder(tokens, xa: encoder(mel))
         return (logits, qk)
     }
-    public func callAsFunction(mel: MLXArray, tokens: MLXArray) -> MLXArray {
-        decoder(tokens, xa: encoder(mel)).0
-    }
+    public func callAsFunction(mel: MLXArray, tokens: MLXArray) -> MLXArray { decoder(tokens, xa: encoder(mel)).0 }
 }
+

--- a/Libraries/MLXWhisper/WhisperModelFactory.swift
+++ b/Libraries/MLXWhisper/WhisperModelFactory.swift
@@ -16,15 +16,15 @@ public actor WhisperModelContainer {
     }
 
     public func transcribe(file path: String) throws -> String {
-        let mel = try logMelSpectrogram(try loadAudio(path))
+        let mel = logMelSpectrogram(try loadAudio(path))
         var tokens = MLXArray([tokenizer.bosTokenId ?? 0])
         var result = ""
-        for _ in 0 ..< 448 {
-            // let logits = model(mel: mel[.newAxis, ...], tokens: tokens[.newAxis, ...])
-            // let next = Int(argmax(logits[0, -1]))
-            // if next == tokenizer.eosTokenId { break }
-            // tokens = concatenated([tokens, MLXArray([next])], axis: 0)
-            // result += tokenizer.decode([next])
+        for _ in 0..<448 {
+            let logits = model(mel: mel[.newAxis, ...], tokens: tokens[.newAxis, ...])
+            let next = Int(argmax(logits[0, -1]))
+            if next == tokenizer.eosTokenId { break }
+            tokens = concatenated([tokens, MLXArray([next])], axis: 0)
+            result += tokenizer.decode([next])
         }
         return result
     }
@@ -48,7 +48,6 @@ public class WhisperModelFactory: Sendable {
             hub: hub, configuration: configuration, dtype: dtype,
             progressHandler: progressHandler)
         let tokenizer = try await loadTokenizer(configuration: configuration, hub: hub)
-        return WhisperModelContainer(
-            model: model, tokenizer: tokenizer, configuration: configuration)
+        return WhisperModelContainer(model: model, tokenizer: tokenizer, configuration: configuration)
     }
 }


### PR DESCRIPTION
## Summary
- restore Whisper Swift implementation using MLX
- load mel filterbank from bundled `mel_filters.npz`
- enable loading weights from HF hub
- restore transcription logic and model factory

## Testing
- `swift test --filter MLXWhisperTests` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_683fd68cf1c08331b5d4807016514b11